### PR TITLE
Apple Port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,10 @@ if (WIN32)
    set (KMS_MESSAGE_SOURCES ${KMS_MESSAGE_SOURCES}
       src/kms_crypto_windows.c
    )
+elseif (APPLE)
+   set (KMS_MESSAGE_SOURCES ${KMS_MESSAGE_SOURCES}
+      src/kms_crypto_apple.c
+   )
 else()
    set (KMS_MESSAGE_SOURCES ${KMS_MESSAGE_SOURCES}
       src/kms_crypto_openssl.c
@@ -61,6 +65,8 @@ add_library (
 if (WIN32)
    target_link_libraries(kms_message "bcrypt")
    target_link_libraries(kms_message_static "bcrypt")
+elseif (APPLE)
+   # Nothing
 else()
    include (FindOpenSSL)
    target_link_libraries(kms_message "${OPENSSL_LIBRARIES}")
@@ -70,12 +76,12 @@ else()
 endif()
 
 if ( CMAKE_COMPILER_IS_GNUCC )
-    set(CMAKE_C_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-function  -Werror")
+    set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -Wall -Wno-unused-function  -Werror")
 endif()
 if ( MSVC )
     # W4273 - inconsistent dll linkage
     # W4996 - POSIX name for this item is deprecated
-    set(CMAKE_C_FLAGS  "${CMAKE_CXX_FLAGS} /W3 /wd4273 /wd4996 /D_CRT_SECURE_NO_WARNINGS /WX")
+    set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} /W3 /wd4273 /wd4996 /D_CRT_SECURE_NO_WARNINGS /WX")
 endif()
 
 set_target_properties (kms_message PROPERTIES
@@ -180,6 +186,8 @@ target_include_directories(test_kms_request PRIVATE  ${PROJECT_SOURCE_DIR})
 
 if (WIN32)
    target_link_libraries(test_kms_request "bcrypt")
+elseif (APPLE)
+   # Nothing
 else()
    include (FindOpenSSL)
    target_link_libraries(test_kms_request "${OPENSSL_LIBRARIES}")

--- a/src/kms_crypto_apple.c
+++ b/src/kms_crypto_apple.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kms_crypto.h"
+
+#include <CommonCrypto/CommonDigest.h>
+#include <CommonCrypto/CommonHMAC.h>
+
+int
+kms_crypto_init ()
+{
+   return 0;
+}
+
+void
+kms_crypto_cleanup ()
+{
+}
+
+bool
+kms_sha256 (const char *input, size_t len, unsigned char *hash_out)
+{
+   CC_SHA256_CTX ctx;
+   CC_SHA256_Init (&ctx);
+   CC_SHA256_Update (&ctx, input, len);
+   CC_SHA256_Final (hash_out, &ctx);
+   return true;
+}
+
+bool
+kms_sha256_hmac (const char *key_input,
+                 size_t key_len,
+                 const char *input,
+                 size_t len,
+                 unsigned char *hash_out)
+{
+   CCHmac (kCCHmacAlgSHA256, key_input, key_len, input, len, hash_out);
+   return true;
+}


### PR DESCRIPTION
The Apple port is pretty straight forward. As far as I know, clang is automatically include the libraries for the crypto library so I do not need to specify any.

Also fixed minor things in CMakeLists.txt