### PR TITLE
C++ support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ else()
 endif()
 
 if ( CMAKE_COMPILER_IS_GNUCC )
-    set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -Wall -Wno-unused-function  -Werror")
+    set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -Wall -Wno-unused-function -Wsign-compare -Werror")
 endif()
 if ( MSVC )
     # W4273 - inconsistent dll linkage

--- a/src/kms_message/kms_b64.h
+++ b/src/kms_message/kms_b64.h
@@ -22,6 +22,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 KMS_MSG_EXPORT (void)
 kms_message_b64_initialize_rmap (void);
 
@@ -33,5 +37,9 @@ kms_message_b64_ntop (uint8_t const *src,
 
 KMS_MSG_EXPORT (int)
 kms_message_b64_pton (char const *src, uint8_t *target, size_t targsize);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* KMS_MESSAGE_B64_H */

--- a/src/kms_message/kms_decrypt_request.h
+++ b/src/kms_message/kms_decrypt_request.h
@@ -19,9 +19,17 @@
 
 #include "kms_message.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 KMS_MSG_EXPORT (kms_request_t *)
 kms_decrypt_request_new (const uint8_t *ciphertext_blob,
                          size_t len,
                          const kms_request_opt_t *opt);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* KMS_DECRYPT_REQUEST_H */

--- a/src/kms_message/kms_encrypt_request.h
+++ b/src/kms_message/kms_encrypt_request.h
@@ -19,9 +19,18 @@
 
 #include "kms_message.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 KMS_MSG_EXPORT (kms_request_t *)
 kms_encrypt_request_new (const char *plaintext,
                          const char *key_id,
                          const kms_request_opt_t *opt);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 
 #endif /* KMS_ENCRYPT_REQUEST_H */

--- a/src/kms_message/kms_message_defines.h
+++ b/src/kms_message/kms_message_defines.h
@@ -40,9 +40,17 @@
 
 #define KMS_MSG_EXPORT(type) KMS_MSG_API type KMS_MSG_CALL
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 KMS_MSG_EXPORT (int)
 kms_message_init (void);
 KMS_MSG_EXPORT (void)
 kms_message_cleanup (void);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* KMS_MESSAGE_DEFINES_H */

--- a/src/kms_message/kms_request.h
+++ b/src/kms_message/kms_request.h
@@ -24,6 +24,10 @@
 #include <stdlib.h>
 #include <time.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct _kms_request_t kms_request_t;
 
 KMS_MSG_EXPORT (kms_request_t *)
@@ -66,5 +70,9 @@ KMS_MSG_EXPORT (char *)
 kms_request_get_signature (kms_request_t *request);
 KMS_MSG_EXPORT (char *)
 kms_request_get_signed (kms_request_t *request);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* KMS_REQUEST_H */

--- a/src/kms_message/kms_request_opt.h
+++ b/src/kms_message/kms_request_opt.h
@@ -21,6 +21,10 @@
 
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct _kms_request_opt_t kms_request_opt_t;
 
 KMS_MSG_EXPORT (kms_request_opt_t *)
@@ -30,5 +34,9 @@ kms_request_opt_destroy (kms_request_opt_t *request);
 KMS_MSG_EXPORT (void)
 kms_request_opt_set_connection_close (kms_request_opt_t *opt,
                                       bool connection_close);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* KMS_REQUEST_OPT_H */

--- a/src/kms_message/kms_response.h
+++ b/src/kms_message/kms_response.h
@@ -19,9 +19,17 @@
 
 #include "kms_message.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct _kms_response_t kms_response_t;
 
 KMS_MSG_EXPORT (const char *) kms_response_get_body (kms_response_t *reply);
 KMS_MSG_EXPORT (void) kms_response_destroy (kms_response_t *reply);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* KMS_RESPONSE_H */

--- a/src/kms_message/kms_response_parser.h
+++ b/src/kms_message/kms_response_parser.h
@@ -20,6 +20,10 @@
 #include "kms_message.h"
 #include "kms_response.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct _kms_response_parser_t kms_response_parser_t;
 
 KMS_MSG_EXPORT (kms_response_parser_t *)
@@ -38,5 +42,9 @@ kms_response_parser_get_response (kms_response_parser_t *parser);
 
 KMS_MSG_EXPORT (void)
 kms_response_parser_destroy (kms_response_parser_t *parser);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* KMS_RESPONSE_PARSER_H */

--- a/src/kms_response_parser.c
+++ b/src/kms_response_parser.c
@@ -194,7 +194,7 @@ kms_response_parser_feed (kms_response_parser_t *parser,
    curr = (int) raw->len;
    kms_request_str_append_chars (raw, (char *) buf, len);
    /* process the new data appended. */
-   while (curr < raw->len) {
+   while (curr < (int) raw->len) {
       switch (parser->state) {
       case PARSING_STATUS_LINE:
       case PARSING_HEADER:


### PR DESCRIPTION
Here are two sets of fixes from my work integrating kms-message into the shell

1. Add C++ support to the headers.
Just needed to wrap all the functions in extern "C".

2. Fix a signed comparison warning and added it to CMakeLists.txt