### PR TITLE
Take length for plaintext in kms_encrypt_request_new

### DIFF
--- a/src/kms_encrypt_request.c
+++ b/src/kms_encrypt_request.c
@@ -21,11 +21,11 @@
 #include "kms_request_str.h"
 
 kms_request_t *
-kms_encrypt_request_new (const char *plaintext,
+kms_encrypt_request_new (const uint8_t *plaintext,
+                         size_t plaintext_length,
                          const char *key_id,
                          const kms_request_opt_t *opt)
 {
-   size_t plain_len;
    kms_request_t *request;
    size_t b64_len;
    char *b64 = NULL;
@@ -43,8 +43,7 @@ kms_encrypt_request_new (const char *plaintext,
       goto done;
    }
 
-   plain_len = strlen (plaintext);
-   b64_len = (plain_len / 3 + 1) * 4 + 1;
+   b64_len = (plaintext_length / 3 + 1) * 4 + 1;
    if (!(b64 = malloc (b64_len))) {
       KMS_ERROR (request,
                  "Could not allocate %d bytes for base64-encoding payload",
@@ -53,7 +52,7 @@ kms_encrypt_request_new (const char *plaintext,
    }
 
    if (kms_message_b64_ntop (
-          (const uint8_t *) plaintext, plain_len, b64, b64_len) == -1) {
+          (const uint8_t *) plaintext, plaintext_length, b64, b64_len) == -1) {
       KMS_ERROR (request, "Could not base64-encode plaintext");
       goto done;
    }

--- a/src/kms_message/kms_encrypt_request.h
+++ b/src/kms_message/kms_encrypt_request.h
@@ -20,7 +20,8 @@
 #include "kms_message.h"
 
 KMS_MSG_EXPORT (kms_request_t *)
-kms_encrypt_request_new (const char *plaintext,
+kms_encrypt_request_new (const uint8_t *plaintext,
+                         size_t plaintext_length,
                          const char *key_id,
                          const kms_request_opt_t *opt);
 

--- a/test/test_kms_request.c
+++ b/test/test_kms_request.c
@@ -703,7 +703,8 @@ decrypt_request_test (void)
 void
 encrypt_request_test (void)
 {
-   kms_request_t *request = kms_encrypt_request_new ("foobar", "alias/1", NULL);
+   char* plaintext = "foobar";
+   kms_request_t *request = kms_encrypt_request_new ((uint8_t*) plaintext, strlen(plaintext), "alias/1", NULL);
 
    set_test_date (request);
    kms_request_set_region (request, "us-east-1");


### PR DESCRIPTION
Plaintext is not actually text but a binary blob so we cannot compute the length with strlen